### PR TITLE
Several editorial changes and rewrites

### DIFF
--- a/.includes.mk
+++ b/.includes.mk
@@ -1,3 +1,0 @@
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-QSF-KEM(ML-KEM-768,P-256)-XOF(SHAKE256)-KDF(SHA3-256).txt
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-KitchenSink-KEM(ML-KEM-768,X25519)-XOF(SHAKE256)-KDF(HKDF-SHA-256).txt
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-QSF-KEM(ML-KEM-1024,P-384)-XOF(SHAKE256)-KDF(SHA3-256).txt

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -139,24 +139,49 @@ informative:
 
 --- abstract
 
-This document defines generic techniques to achive hybrid
-post-quantum/traditional (PQ/T) key encapsulation mechanisms (KEMs) from
-post-quantum and traditional component algorithms that meet specified
-security properties.
+"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+in contrast to "traditional" algorithms.  However, given the novelty of PQ
+algorithms, there is some concern that PQ algorithms currently believed to be
+secure will be broken.  Hybrid constructions that combine both PQ and
+traditional algorithms can help moderate this risk while still providing
+security against quantum attack.  In this document, we define constructions for
+hybrid Key Encapsulation Mechanisms (KEMs) based on combining a traditional KEM
+and a PQ KEM.  Hybrid KEMs using these constructions provide strong security
+properties as long as the undelying algorithms are secure.
 
 --- middle
 
 # Introduction {#intro}
 
-There are many choices that can be made when specifying a hybrid KEM: the
-constituent KEMs; their security levels; the combiner; and the hash within,
-to name but a few. Having too many similar options are a burden to the
-ecosystem.
+"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+in contrast to "traditional" algorithms.  Key Encapsulation Mechanisms (KEMs)
+are an area of particular concern.  As of this writing, it is unlikely that a
+quantum computer already exists, but it is possible that one might be created in
+the near future.  In order to address "harvest now, decrypt later" attacks,
+protocols must integrate post-quantum algorithms for confidentiality protection.
+In particular, public-key algrotihsm for key establishment must be replaced with
+PQ KEMs.
 
-The aim of this document is provide a small set of techniques for
-constructing hybrid KEMs designed to achieve specific security properties
-given conforming component algorithms, that should be suitable for the vast
-majority of use cases.
+Given the novelty of PQ algorithms, however there is some concern that PQ
+algorithms currently believed to be secure will be broken.  Hybrid
+constructions that combine both PQ and traditional algorithms can help moderate
+this risk while still providing security against quantum attack.  If construted
+properly, a hybrid KEM will retain the properties of either constituent KEM
+even if the other KEM is compromised.  If the PQ KEM is broken by new
+cryptanalysis, then the hybrid KEM should continue to provide security against
+non-quantum attackers by virtue of its traditional KEM component.  If the
+traditional KEM is brken by a quantum computer, then the hybrid KEM should
+continue to resist quantum attack by virtue of its PQ KEM component.
+
+In this document, we define constructions for hybrid Key Encapsulation
+Mechanisms (KEMs) based on combining a traditional KEM and a PQ KEM.  Hybrid
+KEMs using these constructions provide strong security properties as long as
+the undelying algorithms are secure.
+
+The aim of this document is provide a small set of techniques for constructing
+hybrid KEMs designed to achieve specific security properties given conforming
+component algorithms, that should be suitable for the vast majority of use
+cases.
 
 # Requirements Notation
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -162,10 +162,6 @@ The following terms are used throughout this document:
   by a cryptographically-secure random number generator.
 - `concat(x0, ..., xN)`: Concatenation of byte strings.  `concat(0x01,
   0x0203, 0x040506) = 0x010203040506`.
-- `I2OSP(n, w)`: Convert non-negative integer `n` to a `w`-length, big-endian
-  byte string, as described in {{!RFC8017}}.
-- `OS2IP(x)`: Convert byte string `x` to a non-negative integer, as described
-  in {{!RFC8017}}, assuming big-endian byte order.
 
 When `x` is a byte string, we use the notation `x[..i]` and `x[i..]` to
 denote the slice of bytes in `x` starting from the beginning of `x` and


### PR DESCRIPTION
This PR makes several primarily editorial changes, in preparation for the more significant edits to the combiners and security properties sections.

* (pk, sk) -> (ek, dk)
* New text in the abstract and introduction
* Removes a couple of unnecessary function definitions
* Clean up in the definition of the KEM interface
* Rewrote the DH section as a KEM-to-DH construction

The last change is the most substantial one.  The current combiner constructions make explicit reference to the DH functions of the T algorithm.  The idea of this rewrite is to handle both the PQ and T algorithms through the KEM interface.  

Handling both algorithms through the same interface is aesthetically nicer, since things will be more parallel, but could also allow for non-DH options like RSA.  At least in principle; I would object to actually spending words on such a possibility in this document.  In fact, I'm not totally sure we need to have the DH KEM construction in the main text, as opposed to having it in an appendix that is referred to as necessary.  (I also thought about moving it to the concrete combiners document, but it seems generic enough and useful enough as a motivator to be included here.)

I'm not sure why `includes.mk` got deleted.  I presume it was was something in the tooling; I didn't do it deliberately.