### PR TITLE
Hybrid constructions

### DIFF
--- a/.includes.mk
+++ b/.includes.mk
@@ -1,3 +1,0 @@
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-QSF-KEM(ML-KEM-768,P-256)-XOF(SHAKE256)-KDF(SHA3-256).txt
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-KitchenSink-KEM(ML-KEM-768,X25519)-XOF(SHAKE256)-KDF(HKDF-SHA-256).txt
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-QSF-KEM(ML-KEM-1024,P-384)-XOF(SHAKE256)-KDF(SHA3-256).txt

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -139,24 +139,49 @@ informative:
 
 --- abstract
 
-This document defines generic techniques to achive hybrid
-post-quantum/traditional (PQ/T) key encapsulation mechanisms (KEMs) from
-post-quantum and traditional component algorithms that meet specified
-security properties.
+"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+in contrast to "traditional" algorithms.  However, given the novelty of PQ
+algorithms, there is some concern that PQ algorithms currently believed to be
+secure will be broken.  Hybrid constructions that combine both PQ and
+traditional algorithms can help moderate this risk while still providing
+security against quantum attack.  In this document, we define constructions for
+hybrid Key Encapsulation Mechanisms (KEMs) based on combining a traditional KEM
+and a PQ KEM.  Hybrid KEMs using these constructions provide strong security
+properties as long as the undelying algorithms are secure.
 
 --- middle
 
 # Introduction {#intro}
 
-There are many choices that can be made when specifying a hybrid KEM: the
-constituent KEMs; their security levels; the combiner; and the hash within,
-to name but a few. Having too many similar options are a burden to the
-ecosystem.
+"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+in contrast to "traditional" algorithms.  Key Encapsulation Mechanisms (KEMs)
+are an area of particular concern.  As of this writing, it is unlikely that a
+quantum computer already exists, but it is possible that one might be created in
+the near future.  In order to address "harvest now, decrypt later" attacks,
+protocols must integrate post-quantum algorithms for confidentiality protection.
+In particular, public-key algrotihsm for key establishment must be replaced with
+PQ KEMs.
 
-The aim of this document is provide a small set of techniques for
-constructing hybrid KEMs designed to achieve specific security properties
-given conforming component algorithms, that should be suitable for the vast
-majority of use cases.
+Given the novelty of PQ algorithms, however there is some concern that PQ
+algorithms currently believed to be secure will be broken.  Hybrid
+constructions that combine both PQ and traditional algorithms can help moderate
+this risk while still providing security against quantum attack.  If construted
+properly, a hybrid KEM will retain the properties of either constituent KEM
+even if the other KEM is compromised.  If the PQ KEM is broken by new
+cryptanalysis, then the hybrid KEM should continue to provide security against
+non-quantum attackers by virtue of its traditional KEM component.  If the
+traditional KEM is brken by a quantum computer, then the hybrid KEM should
+continue to resist quantum attack by virtue of its PQ KEM component.
+
+In this document, we define constructions for hybrid Key Encapsulation
+Mechanisms (KEMs) based on combining a traditional KEM and a PQ KEM.  Hybrid
+KEMs using these constructions provide strong security properties as long as
+the undelying algorithms are secure.
+
+The aim of this document is provide a small set of techniques for constructing
+hybrid KEMs designed to achieve specific security properties given conforming
+component algorithms, that should be suitable for the vast majority of use
+cases.
 
 # Requirements Notation
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -162,10 +162,6 @@ The following terms are used throughout this document:
   by a cryptographically-secure random number generator.
 - `concat(x0, ..., xN)`: Concatenation of byte strings.  `concat(0x01,
   0x0203, 0x040506) = 0x010203040506`.
-- `I2OSP(n, w)`: Convert non-negative integer `n` to a `w`-length, big-endian
-  byte string, as described in {{!RFC8017}}.
-- `OS2IP(x)`: Convert byte string `x` to a non-negative integer, as described
-  in {{!RFC8017}}, assuming big-endian byte order.
 
 When `x` is a byte string, we use the notation `x[..i]` and `x[i..]` to
 denote the slice of bytes in `x` starting from the beginning of `x` and

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -25,7 +25,7 @@ informative:
     date: Jan, 2001
     author:
       -
-        ins: Michel Abdalla1
+        ins: Michel Abdalla
       -
         ins: Mihir Bellare1
       -
@@ -153,16 +153,15 @@ properties as long as the undelying algorithms are secure.
 
 # Introduction {#intro}
 
-"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
-in contrast to "traditional" algorithms.  Key Encapsulation Mechanisms (KEMs)
-are an area of particular concern.  As of this writing, it is unlikely that a
-quantum computer already exists, but it is possible that one might be created in
-the near future.  In order to address "harvest now, decrypt later" attacks,
-protocols must integrate post-quantum algorithms for confidentiality protection.
-In particular, public-key algrotihsm for key establishment must be replaced with
-PQ KEMs.
+Post-quantum (PQ) algorithms offer a redesign of traditional algorithms tailored
+towards resisting attack from a quantum computer. Key Encapsulation Mechanisms
+(KEMs), are a standardized algorithm type that can be used to build protocols in
+lieu of traditional, quantum-vulnerable variants such as Diffie-Hellman (DH)
+based protocols.  Upgrading protocols to use PQ KEMs is a priority for the
+protocol design community, due to the possibility of "harvest now, decrypt
+later" attacks.
 
-Given the novelty of PQ algorithms, however there is some concern that PQ
+Given the novelty of PQ algorithms, however, there is some concern that PQ
 algorithms currently believed to be secure will be broken.  Hybrid
 constructions that combine both PQ and traditional algorithms can help moderate
 this risk while still providing security against quantum attack.  If construted
@@ -309,8 +308,6 @@ pseudorandom function (PRF) in the standard model {{GHP2018}} and independent
 random oracle in the random oracle model (ROM).
 
 ## KEM from Diffie-Hellman {#group}
-
-<!-- TODO(RLB) Move this to an appendix? -->
 
 This section describes a simple KEM built from a Diffie-Hellman group.  **This
 KEM is not IND-CCA secure**. It is, however IND-CPA secure under either the

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -27,7 +27,7 @@ informative:
       -
         ins: Michel Abdalla
       -
-        ins: Mihir Bellare1
+        ins: Mihir Bellare
       -
         ins: Phillip Rogaway
 
@@ -139,7 +139,7 @@ informative:
 
 --- abstract
 
-"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+"Post-quantum" (PQ) algorithms are designed to resist attack by a quantum computer,
 in contrast to "traditional" algorithms.  However, given the novelty of PQ
 algorithms, there is some concern that PQ algorithms currently believed to be
 secure will be broken.  Hybrid constructions that combine both PQ and
@@ -169,18 +169,20 @@ properly, a hybrid KEM will retain the properties of either constituent KEM
 even if the other KEM is compromised.  If the PQ KEM is broken by new
 cryptanalysis, then the hybrid KEM should continue to provide security against
 non-quantum attackers by virtue of its traditional KEM component.  If the
-traditional KEM is brken by a quantum computer, then the hybrid KEM should
+traditional KEM is broken by a quantum computer, then the hybrid KEM should
 continue to resist quantum attack by virtue of its PQ KEM component.
 
-In this document, we define constructions for hybrid Key Encapsulation
-Mechanisms (KEMs) based on combining a traditional KEM and a PQ KEM.  Hybrid
-KEMs using these constructions provide strong security properties as long as
-the undelying algorithms are secure.
+In addition to guarding against algorithm flaws, this property also guards
+against flaws in implementations, such as timing attacks.  Hybrid KEMs can also
+facilitate faster deployment of PQ security by allowing applications to
+incorporate PQ algorithms while still meeting compliance requirements based on
+traditional algorithms.
 
-The aim of this document is provide a small set of techniques for constructing
-hybrid KEMs designed to achieve specific security properties given conforming
-component algorithms, that should be suitable for the vast majority of use
-cases.
+In this document, we define constructions for hybrid KEMs based on combining a
+traditional KEM and a PQ KEM.  The aim of this document is provide a small set
+of techniques for constructing hybrid KEMs designed to achieve specific security
+properties given conforming component algorithms, that should be suitable for
+the vast majority of use cases.
 
 # Requirements Notation
 
@@ -310,14 +312,10 @@ random oracle in the random oracle model (ROM).
 ## KEM from Diffie-Hellman {#group}
 
 This section describes a simple KEM built from a Diffie-Hellman group.  **This
-KEM is not IND-CCA secure**. It is, however IND-CPA secure under either the
-Decisional Diffie-Hellman assumption or the Hashed Decisional Diffie-Hellman
-assumption, depending on the details of the ElementToSharedSecret function
-{{ABR01}}.
-
-The KEM construction here differs from the DHKEM construction in the HPKE
-specification {{RFC9180}}.  DHKEM performs additional hashing steps to mix
-certain metadata into the shared secret; this construction is more minimal.
+KEM is not a secure KEM in the sense of the IND-CCA standard usually applied (it
+meets the lower IND-CPA standard {{ABR01}}), and thus should not be used on its
+own.**  However, using the constructions in this document, it can be used as a
+component of an IND-CCA hybrid KEM, as discussed in {{security-considerations}}.
 
 The traditional Diffie-Hellman construction depends on an abelian group G with a
 chosen group generator or "base point" `B`, in which the discrete-log problem is

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -295,7 +295,7 @@ as opposed to "public" and "secret".
 Functionally, a hash function is simply a function that produces a fixed-length
 output byte string from an input byte string of arbitrary length.
 
-- `Nh` - The length in bytes of an output from this hash function. 
+- `Nh` - The length in bytes of an output from this hash function.
 - `Hash(input) -> output`: Produce a byte string of length `Nh` from an input
   byte string.
 
@@ -305,31 +305,10 @@ as `Foo(input)` instead of `Foo.Hash(input)`.
 
 Hash function used with the constructions in this document should be structured
 so that they can be regarded as random oracles in either the classical or
-quantum random oracle model.
-
-
-## `XOF` {#xof}
-
-Extendable-output function (XOF). A function on bit strings in which the
-output can be extended to any desired length. Ought to satisfy the following
-properties as long as the specified output length is sufficiently long to
-prevent trivial attacks:
-
-1. (One-way) It is computationally infeasible to find any input that maps to
-   any new pre-specified output.
-
-2. (Collision-resistant) It is computationally infeasible to find any two
-   distinct inputs that map to the same output.
-
-MUST provide the bit-security required to source input randomness for PQ/T
-components from a seed that is expanded to a output length, of which a subset
-is passed to the component key generation algorithms.
-
-## Key Derivation Function `KDF` {#kdf}
-
-A secure key derivation function (KDF) that is modeled as a secure
-pseudorandom function (PRF) in the standard model {{GHP2018}} and independent
-random oracle in the random oracle model (ROM).
+quantum random oracle model.  (Note that this property implies standard hash
+function properties such as collision resistance and second preimage
+resistance.)  Each hash function we refer to should be an independent random
+oracle.
 
 ## KEM from Diffie-Hellman {#group}
 
@@ -542,19 +521,20 @@ hashes for no utility, and the `Everything` combiner should be preferred.
 
 <!-- TODO example: Raw ECDH + Classic McEliece -->
 
-### Traditional Only
+### Only Traditional
 
 ```
-def Traditional(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
+def Only Traditional(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
     return concat(ss_PQ, ss_T, ct_T, ek_T, label)
 ```
 
 This combiner produces an even smaller hash input than the `PreHashedKeys`
-combiner, even in cases where keys are not reused.
+combiner, even in cases where keys are not reused, by hashing only the
+traditional metadata.
 
 It is, however, less universal than the `Everything` or `PreHashedKeys`
 combiners.  Its security depends on the constituent KEMs having certain
-additional properties, as discussed in {{traditional-only-sec}}.
+additional properties, as discussed in {{only-traditional-sec}}.
 
 <!-- TODO example: Raw ECDH + ML-KEM -->
 
@@ -573,6 +553,26 @@ stringent requirements on the constituent KEMs, as discussed in
 <!-- For example: DHKEM + ML-KEM -->
 
 # Security Considerations
+
+## Security Properties
+
+### INDistinguishability against Chosen-Ciphertext Attacks (IND-CCA)
+
+### Ciphertext Second Preimage Resistance (C2PR)
+
+### Binding Properties (X-BIND-P-Q)
+
+### Survival if One KEM Fails
+
+## Security of the Combiners
+
+### Everything {#everything-sec}
+
+### OnlyTraditional {#only-traditional-sec}
+
+### OnlySharedSecrets {#only-shared-secrets-sec}
+
+# Security Considerations (Original)
 
 Hybrid KEM constructions aim to provide security by combining two or more
 schemes so that security is preserved if all but one schemes are replaced by


### PR DESCRIPTION
This PR builds on #18 by actually defining the hybrid KEM constructions.  First we define the overall KEM structure, being generic over combiner functions, and then we define the combiners.

I have focused on functional definitions here, with security notions and arguments punted to the Security Considerations.  I added an outline of what I think we need the Security Considerations to look like at the end, mainly so that I could have targets for the cross-references above.