### PR TITLE
Reframe in terms of groups ++

### DIFF
--- a/.includes.mk
+++ b/.includes.mk
@@ -1,3 +1,0 @@
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-QSF-KEM(ML-KEM-768,P-256)-XOF(SHAKE256)-KDF(SHA3-256).txt
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-KitchenSink-KEM(ML-KEM-768,X25519)-XOF(SHAKE256)-KDF(HKDF-SHA-256).txt
-draft-irtf-cfrg-hybrid-kems.xml: ./spec/test-vectors-QSF-KEM(ML-KEM-1024,P-384)-XOF(SHAKE256)-KDF(SHA3-256).txt

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -641,26 +641,6 @@ def Decaps(dk, ct):
 
 # Security Considerations
 
-## Security Properties
-
-### INDistinguishability against Chosen-Ciphertext Attacks (IND-CCA)
-
-### Ciphertext Second Preimage Resistance (C2PR)
-
-### Binding Properties (X-BIND-P-Q)
-
-### Survival if One KEM Fails
-
-## Security of the Combiners
-
-### Everything {#everything-sec}
-
-### OnlyTraditional {#only-traditional-sec}
-
-### OnlySharedSecrets {#only-shared-secrets-sec}
-
-# Security Considerations (Original)
-
 Hybrid KEM constructions aim to provide security by combining two or more
 schemes so that security is preserved if all but one schemes are replaced by
 an arbitrarily bad scheme. Informally, these hybrid KEMs are secure if the `KDF`

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -153,36 +153,36 @@ properties as long as the undelying algorithms are secure.
 
 # Introduction {#intro}
 
-Post-quantum (PQ) algorithms offer a redesign of traditional algorithms tailored
+Post-quantum (PQ) algorithms offer new constructions based on problems tailored
 towards resisting attack from a quantum computer. Key Encapsulation Mechanisms
 (KEMs), are a standardized algorithm type that can be used to build protocols in
-lieu of traditional, quantum-vulnerable variants such as Diffie-Hellman (DH)
-based protocols.  Upgrading protocols to use PQ KEMs is a priority for the
-protocol design community, due to the possibility of "harvest now, decrypt
-later" attacks.
+lieu of traditional, quantum-vulnerable variants such as finite field or
+elliptic curve Diffie-Hellman (DH) based protocols. Upgrading key establishment
+protocols to use PQ KEMs is a priority for the protocol design community, due to
+the possibility of "harvest now, decrypt later" attacks.
 
 Given the novelty of PQ algorithms, however, there is some concern that PQ
 algorithms currently believed to be secure will be broken.  Hybrid
 constructions that combine both PQ and traditional algorithms can help moderate
 this risk while still providing security against quantum attack.  If construted
-properly, a hybrid KEM will retain the properties of either constituent KEM
-even if the other KEM is compromised.  If the PQ KEM is broken by new
-cryptanalysis, then the hybrid KEM should continue to provide security against
-non-quantum attackers by virtue of its traditional KEM component.  If the
-traditional KEM is broken by a quantum computer, then the hybrid KEM should
-continue to resist quantum attack by virtue of its PQ KEM component.
+properly, a hybrid KEM will retain certain security properties even if one of
+the two constituent KEMs is compromised.  If the PQ KEM is broken, then the
+hybrid KEM should continue to provide security against non-quantum attackers by
+virtue of its traditional KEM component.  If the traditional KEM is broken by a
+quantum computer, then the hybrid KEM should continue to resist quantum attack
+by virtue of its PQ KEM component.
 
-In addition to guarding against algorithm flaws, this property also guards
+In addition to guarding against algorithm weaknesses, this property also guards
 against flaws in implementations, such as timing attacks.  Hybrid KEMs can also
 facilitate faster deployment of PQ security by allowing applications to
 incorporate PQ algorithms while still meeting compliance requirements based on
 traditional algorithms.
 
 In this document, we define constructions for hybrid KEMs based on combining a
-traditional KEM and a PQ KEM.  The aim of this document is provide a small set
-of techniques for constructing hybrid KEMs designed to achieve specific security
-properties given conforming component algorithms, that should be suitable for
-the vast majority of use cases.
+traditional algorithm and a PQ KEM.  The aim of this document is provide a small
+set of techniques for constructing hybrid KEMs designed to achieve specific
+security properties given conforming component algorithms, which should make it
+suitable for the majority of use cases.
 
 # Requirements Notation
 
@@ -266,6 +266,13 @@ A Key Encapsulation Mechanism (KEMs) comprises the following algorithms:
   as input a secret decapsulation key `dk` and ciphertext `ct` and outputs a
   shared secret `ss`.
 
+> Definitions of KEM in the literature typically do not explicitly include the
+> `DeriveKeyPair` function.  It can be viewed as a "derandomized" version of
+> `GenerateKeyPair`, in which the randomness used by the randomized algorithm is
+> made explicit.  We call it out explicitly here because `DeriveKeyPair` is
+> important to allow KEMs to integrate with protocols such as HPKE {{?RFC9180}}
+> and MLS {{?RFC9420}}.
+
 A KEM may also provide a deterministic version of `Encaps` (e.g., for purposes
 of testing):
 
@@ -273,6 +280,9 @@ of testing):
    encapsulation algorithm, which takes as input a public encapsulation key
    `ek` and randomness `randomness`, and outputs a ciphertext `ct` and shared
    secret `shared_secret`.
+
+<!-- XXX(RLB): Maybe we should make this optional and parallel to `EncapsDerand`
+-->
 
 We assume that the values produced and consumed by the above functions are all
 byte strings, with fixed lengths:
@@ -283,12 +293,12 @@ byte strings, with fixed lengths:
 - `Nct`: The length in bytes of a ciphertext produced by Encaps
 - `Nss`: The length in bytes of a shared secret produced by Encaps or Decaps
 
-This interface is effectively the same as the one defined in the Hybrid Public
-Key Encryption (HPKE) specification {{?RFC9180}}.  The only difference is that
-here we assume that all values are byte strings, whereas in HPKE keys are opaque
-by default and serialized or deserialized as needed.  We also use slightly
-different terminology for keys, emphasizing "encapsulation" and "decapsulation"
-as opposed to "public" and "secret".
+> This interface is effectively the same as the one defined in the Hybrid Public
+> Key Encryption (HPKE) specification {{?RFC9180}}.  The only difference is that
+> here we assume that all values are byte strings, whereas in HPKE keys are
+> opaque by default and serialized or deserialized as needed.  We also use
+> slightly different terminology for keys, emphasizing "encapsulation" and
+> "decapsulation" as opposed to "public" and "secret".
 
 ## Hash functions {#hash}
 
@@ -499,7 +509,7 @@ large, causing `CombinerHash` to process a large input.
 
 <!-- TODO example: Raw ECDH + something with short keys and no binding (HQC?) -->
 
-## Pre-Hash Encapsulation Keys
+### Pre-Hash Encapsulation Keys
 
 ```
 def PreHashedKeys(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
@@ -524,7 +534,7 @@ hashes for no utility, and the `Everything` combiner should be preferred.
 ### Only Traditional
 
 ```
-def Only Traditional(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
+def OnlyTraditional(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
     return concat(ss_PQ, ss_T, ct_T, ek_T, label)
 ```
 
@@ -537,20 +547,6 @@ combiners.  Its security depends on the constituent KEMs having certain
 additional properties, as discussed in {{only-traditional-sec}}.
 
 <!-- TODO example: Raw ECDH + ML-KEM -->
-
-### Only Shared Secrets
-
-```
-def OnlySharedSecrets(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
-    return concat(ss_PQ, ss_T, label)
-```
-
-This combiner is the minimum possible combiner, covering only the shared secrets
-and a domain separation label.  In order to be secure, it places fairly
-stringent requirements on the constituent KEMs, as discussed in
-{{only-shared-secrets-sec}}.
-
-<!-- For example: DHKEM + ML-KEM -->
 
 # Security Considerations
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -397,7 +397,7 @@ fixed lengths:
 > API, however, this KEM would not be secure, so we have preferred to address
 > hybrid KEMs that use elliptic curves directly.
 
-# Hybrid KEM Constructions {#constructions}
+# Hybrid KEM Generic Constructions {#generic-constructions}
 
 In this section, we define three constructions for hybrid KEMs:
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -335,6 +335,10 @@ function properties such as collision resistance and second preimage
 resistance.)  Each hash function we refer to should be an independent random
 oracle.
 
+For QSF, the KDF function must be a secure random oracle in the random oracle
+model and quantum random oracle model and as a secure pseudorandom
+function (PRF) in the standard model.
+
 ## Nominal Groups {#group}
 
 ~~~ aasvg

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -174,7 +174,7 @@ properties as long as the undelying algorithms are secure.
 # Introduction {#intro}
 
 Post-quantum (PQ) cryptographic schemes offer new constructions based on problems
-conjectured as resistant to attacks possible on a quantum computer. Key 
+conjectured as resistant to attacks possible on a quantum computer. Key
 Encapsulation Mechanisms (KEMs), are a standardized class of cryptographic scheme
 that can be used to build protocols in lieu of traditional, quantum-vulnerable
 variants such as finite field or elliptic curve Diffie-Hellman (DH) based protocols.
@@ -218,7 +218,7 @@ interest to readers, but which are not treated in depth.
 # Notation
 
 This document is consistent with all terminology defined in
-{{I-D.ietf-pquip-pqt-hybrid-terminology}}.
+{{?I-D.ietf-pquip-pqt-hybrid-terminology}}.
 
 The following terms are used throughout this document:
 
@@ -246,8 +246,6 @@ following cryptographic primitives:
 
 - Key Encapsulation Mechanisms {{kems}}
 - Nominal Groups {{group}}
-- Key-derivation Functions {{kdfs}}
-- Extendable-output Functions {{xofs}}
 - Hash Functions {{hash}}
 
 In the remainder of this section, we describe functional aspects of these
@@ -513,7 +511,7 @@ def Encaps(ek):
 
     ekh = KeyHash(concat(ek_T, ek_PQ))
     ss_H = CombinerHash(concat(ss_PQ, ss_T, ct_PQ, ct_T, ekh, label))
-    
+
     ct_H = concat(ct_T, ct_PQ)
     return (ss_H, ct_H)
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -202,7 +202,7 @@ set of techniques to achieve specific security properties given conforming
 component algorithms, which should make these techniques suitable for a broad
 variety of use cases.
 
-The remainder of this document is structured as follows: First, in
+The remainder of this document is structured as follows: first, in
 {{cryptographic-deps}} and {{schemes}}, we define the abstractions on which the
 schemes are built, and then the schemes themselves.  Then, in {{security}}, we
 lay out the security analyses that support these constructions, including the

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -649,9 +649,9 @@ an arbitrarily bad scheme. Informally, these hybrid KEMs are secure if the `KDF`
 is secure, and either the elliptic curve is secure, or the post-quantum KEM is
 secure: this is the 'hybrid' property.
 
-## Security Properties
+## Security Properties {#security-properties}
 
-### IND-CCA Security
+### IND-CCA Security {#ind-cca}
 
 Also known as IND-CCA2 security for general public key encryption, for KEMs
 that encapsulate a new random 'message' each time.
@@ -663,7 +663,7 @@ adversary can recognize which of two messages is encrypted in a given
 ciphertext, even if the two candidate messages are chosen by the adversary
 himself.
 
-### Ciphertext Second Preimage Resistant (C2PRI) Security
+### Ciphertext Second Preimage Resistant (C2PRI) Security {#c2pri}
 
 Also known in the literature as ciphertext collision resistance (CCR).
 
@@ -675,7 +675,7 @@ known as ciphertext second preimage resistance (C2SPI) for KEMs
 {{XWING}}. The same notion has also been described as chosen ciphertext
 resistance elsewhere {{CDM23}}.
 
-## Binding Properties
+## Binding Properties {#binding-properties}
 
 It is often useful for a KEM to have certain "binding properties", by which
 certain parameters determine certain others {{CDM23}}.  These properties are

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -397,12 +397,16 @@ output lengths:
 
 The fixed sizes are for both security and simplicity. 
 
-For instances of the `Extract()`/`Expand()` KDF paradigm such as `HKDF`, we fix the salt s and sizes to fit this form.
+For instances of the `Extract()`/`Expand()` KDF paradigm such as `HKDF`, we fix
+the salt and sizes to fit this form.
 
 The security requirements for KDFs used with the schemes in this document are
 laid out in {{security-requirements}}.
 
-<!-- We must include XOFs because of X-Wing at the least but also because different KEMs/ groups may need different input seed sizes out the back of the function, and pure hash functions are not well suited for this; HKDF allows this via Expand(..., length) but X-Wing does not use HKDF -->
+<!-- We must include XOFs because of X-Wing at the least but also because
+different KEMs/ groups may need different input seed sizes out the back of
+the function, and pure hash functions are not well suited for this; HKDF
+allows this via Expand(..., length) but X-Wing does not use HKDF -->
 
 ## `XOF` {#xofs}
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -169,8 +169,10 @@ properties as long as the undelying algorithms are secure.
 
 # Introduction {#intro}
 
-Post-quantum (PQ) cryptographic schemes offer new constructions based on problems conjectured as resistant to attacks possible on a quantum computer. Key Encapsulation Mechanisms
-(KEMs), are a standardized algorithm type that can be used to build protocols in
+Post-quantum (PQ) cryptographic schemes offer new constructions based on problems
+conjectured as resistant to attacks possible on a quantum computer. Key Encapsulation
+Mechanisms (KEMs), are a standardized class of cryptographic scheme that can be used
+to build protocols in
 lieu of traditional, quantum-vulnerable variants such as finite field or
 lieu of traditional, quantum-vulnerable variants such as finite field or
 elliptic curve Diffie-Hellman (DH) based protocols.

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -139,24 +139,49 @@ informative:
 
 --- abstract
 
-This document defines generic techniques to achive hybrid
-post-quantum/traditional (PQ/T) key encapsulation mechanisms (KEMs) from
-post-quantum and traditional component algorithms that meet specified
-security properties.
+"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+in contrast to "traditional" algorithms.  However, given the novelty of PQ
+algorithms, there is some concern that PQ algorithms currently believed to be
+secure will be broken.  Hybrid constructions that combine both PQ and
+traditional algorithms can help moderate this risk while still providing
+security against quantum attack.  In this document, we define constructions for
+hybrid Key Encapsulation Mechanisms (KEMs) based on combining a traditional KEM
+and a PQ KEM.  Hybrid KEMs using these constructions provide strong security
+properties as long as the undelying algorithms are secure.
 
 --- middle
 
 # Introduction {#intro}
 
-There are many choices that can be made when specifying a hybrid KEM: the
-constituent KEMs; their security levels; the combiner; and the hash within,
-to name but a few. Having too many similar options are a burden to the
-ecosystem.
+"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+in contrast to "traditional" algorithms.  Key Encapsulation Mechanisms (KEMs)
+are an area of particular concern.  As of this writing, it is unlikely that a
+quantum computer already exists, but it is possible that one might be created in
+the near future.  In order to address "harvest now, decrypt later" attacks,
+protocols must integrate post-quantum algorithms for confidentiality protection.
+In particular, public-key algrotihsm for key establishment must be replaced with
+PQ KEMs.
 
-The aim of this document is provide a small set of techniques for
-constructing hybrid KEMs designed to achieve specific security properties
-given conforming component algorithms, that should be suitable for the vast
-majority of use cases.
+Given the novelty of PQ algorithms, however there is some concern that PQ
+algorithms currently believed to be secure will be broken.  Hybrid
+constructions that combine both PQ and traditional algorithms can help moderate
+this risk while still providing security against quantum attack.  If construted
+properly, a hybrid KEM will retain the properties of either constituent KEM
+even if the other KEM is compromised.  If the PQ KEM is broken by new
+cryptanalysis, then the hybrid KEM should continue to provide security against
+non-quantum attackers by virtue of its traditional KEM component.  If the
+traditional KEM is brken by a quantum computer, then the hybrid KEM should
+continue to resist quantum attack by virtue of its PQ KEM component.
+
+In this document, we define constructions for hybrid Key Encapsulation
+Mechanisms (KEMs) based on combining a traditional KEM and a PQ KEM.  Hybrid
+KEMs using these constructions provide strong security properties as long as
+the undelying algorithms are secure.
+
+The aim of this document is provide a small set of techniques for constructing
+hybrid KEMs designed to achieve specific security properties given conforming
+component algorithms, that should be suitable for the vast majority of use
+cases.
 
 # Requirements Notation
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -385,12 +385,12 @@ output lengths:
 
 - `Nin` - The length in bytes of an input to this KDF.
 - `Nout` - The length in bytes of an output from this KDF.
-- `Derive(input) -> output`: Produce a byte string of length `Nout` from an input
+- `KDF(input) -> output`: Produce a byte string of length `Nout` from an input
   byte string.
 
-For simplicity, we will write invocations of a KDF without `Derive` being
-explicit.  Invoking a KDF `Foo` on input `input` will be written as `Foo(input)`
-instead of `Foo.Derive(input)`.
+The fixed sizes are for both security and simplicity. 
+
+For instances of the `Extract()`/`Expand()` KDF paradigm such as `HKDF`, we fix the salt s and sizes to fit this form.
 
 The security requirements for KDFs used with the schemes in this document are
 laid out in {{security-requirements}}.

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -162,10 +162,6 @@ The following terms are used throughout this document:
   by a cryptographically-secure random number generator.
 - `concat(x0, ..., xN)`: Concatenation of byte strings.  `concat(0x01,
   0x0203, 0x040506) = 0x010203040506`.
-- `I2OSP(n, w)`: Convert non-negative integer `n` to a `w`-length, big-endian
-  byte string, as described in {{!RFC8017}}.
-- `OS2IP(x)`: Convert byte string `x` to a non-negative integer, as described
-  in {{!RFC8017}}, assuming big-endian byte order.
 
 When `x` is a byte string, we use the notation `x[..i]` and `x[i..]` to
 denote the slice of bytes in `x` starting from the beginning of `x` and

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -557,7 +557,7 @@ def PseudoDecaps(dk, ct):
 
 The HashEverything and PreHashedKeys hybrid KEMs are instantiated with a
 nominal group by replacing the `KEM_T` methods with the corresponding `Pseudo`
-methods. 
+methods.
 
 ## HashTraditionalOnly
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -169,8 +169,7 @@ properties as long as the undelying algorithms are secure.
 
 # Introduction {#intro}
 
-Post-quantum (PQ) algorithms offer new constructions based on problems tailored
-towards resisting attack from a quantum computer. Key Encapsulation Mechanisms
+Post-quantum (PQ) cryptographic schemes offer new constructions based on problems conjectured as resistant to attacks possible on a quantum computer. Key Encapsulation Mechanisms
 (KEMs), are a standardized algorithm type that can be used to build protocols in
 lieu of traditional, quantum-vulnerable variants such as finite field or
 elliptic curve Diffie-Hellman (DH) based protocols. Upgrading key establishment

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -663,7 +663,7 @@ adversary can recognize which of two messages is encrypted in a given
 ciphertext, even if the two candidate messages are chosen by the adversary
 himself.
 
-### Ciphertext Second Preimage Resistant (C2SPI) Security
+### Ciphertext Second Preimage Resistant (C2PRI) Security
 
 Also known in the literature as ciphertext collision resistance (CCR).
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -170,12 +170,10 @@ properties as long as the undelying algorithms are secure.
 # Introduction {#intro}
 
 Post-quantum (PQ) cryptographic schemes offer new constructions based on problems
-conjectured as resistant to attacks possible on a quantum computer. Key Encapsulation
-Mechanisms (KEMs), are a standardized class of cryptographic scheme that can be used
-to build protocols in
-lieu of traditional, quantum-vulnerable variants such as finite field or
-lieu of traditional, quantum-vulnerable variants such as finite field or
-elliptic curve Diffie-Hellman (DH) based protocols.
+conjectured as resistant to attacks possible on a quantum computer. Key 
+Encapsulation Mechanisms (KEMs), are a standardized class of cryptographic scheme
+that can be used to build protocols in lieu of traditional, quantum-vulnerable
+variants such as finite field or elliptic curve Diffie-Hellman (DH) based protocols.
 
 Given the novelty of PQ algorithms, however, there is some concern that PQ
 algorithms currently believed to be secure will be broken.  Hybrid

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -456,7 +456,7 @@ constituent components:
 * `Label` - A byte string used to label the specific combination of the above
   constituents being used.
 
-The KEMs, groups, KDFs, and XOFs MSUT meet the security requirements in {{#security-requirements}}.
+The KEMs, groups, KDFs, and XOFs MUST meet the security requirements in {{#security-requirements}}.
 
 The constants associated with the hybrid KEM are mostly derived from the
 concatenation of keys and ciphertexts:

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -25,7 +25,7 @@ informative:
     date: Jan, 2001
     author:
       -
-        ins: Michel Abdalla1
+        ins: Michel Abdalla
       -
         ins: Mihir Bellare1
       -
@@ -153,16 +153,15 @@ properties as long as the undelying algorithms are secure.
 
 # Introduction {#intro}
 
-"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
-in contrast to "traditional" algorithms.  Key Encapsulation Mechanisms (KEMs)
-are an area of particular concern.  As of this writing, it is unlikely that a
-quantum computer already exists, but it is possible that one might be created in
-the near future.  In order to address "harvest now, decrypt later" attacks,
-protocols must integrate post-quantum algorithms for confidentiality protection.
-In particular, public-key algrotihsm for key establishment must be replaced with
-PQ KEMs.
+Post-quantum (PQ) algorithms offer a redesign of traditional algorithms tailored
+towards resisting attack from a quantum computer. Key Encapsulation Mechanisms
+(KEMs), are a standardized algorithm type that can be used to build protocols in
+lieu of traditional, quantum-vulnerable variants such as Diffie-Hellman (DH)
+based protocols.  Upgrading protocols to use PQ KEMs is a priority for the
+protocol design community, due to the possibility of "harvest now, decrypt
+later" attacks.
 
-Given the novelty of PQ algorithms, however there is some concern that PQ
+Given the novelty of PQ algorithms, however, there is some concern that PQ
 algorithms currently believed to be secure will be broken.  Hybrid
 constructions that combine both PQ and traditional algorithms can help moderate
 this risk while still providing security against quantum attack.  If construted
@@ -309,8 +308,6 @@ pseudorandom function (PRF) in the standard model {{GHP2018}} and independent
 random oracle in the random oracle model (ROM).
 
 ## KEM from Diffie-Hellman {#group}
-
-<!-- TODO(RLB) Move this to an appendix? -->
 
 This section describes a simple KEM built from a Diffie-Hellman group.  **This
 KEM is not IND-CCA secure**. It is, however IND-CPA secure under either the

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -438,9 +438,9 @@ In this section, we define three schemes for building for hybrid KEMs:
   component is a nominal group and the PQ component has strong binding
   properties
 
-In this section, we define a collection of constructions for hybrid KEMs. These
+In this section, we define several generic constructions for hybrid KEMs. These
 constructions share a common overall structure, differing mainly in how they
-compute the final shared secret.
+compute the final shared secret and the security requirements of their components.
 
 ## HashEverything
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -773,6 +773,12 @@ deterministically defined by the input.
 [[ TODO: Define which properties are provided by the hybrid KEMs in this
 document, and citations to the papers with the corresponding proofs. ]]
 
+All generic constructions in this document produce IND-CCA-secure KEMs 
+when correctly instantiated concretely with cryptographic components that
+meet the respective security requirements. Any changes to the routines,
+including key generation/derivation, are not guaranteed to produce
+secure results.
+
 ## Other Considerations
 
 ### Domain Separation {#domain-separation}

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -692,22 +692,81 @@ FO-transform KEM. Also called ciphertext collision resistance.
 
 ## Security Requirements for Constituent Components {#security-requirements}
 
-> TODO: The text in this section is provisional, intended to give a general idea of
-> direction.  We need to provide more thorough description, and verify that
+> TODO: We need to provide more thorough description, and verify that
 > these requirements align with the requirements of the security proofs in the
 > literature, especially {{GHP2018}} and {{XWING}}.
 
-KEMs must be IND-CCA, except for in HashTraditionalOnly, where they must provide
-certain binding properties as specified in {{XWING}}.
+### Security Requirements for KEMs
 
-Nominal groups must be ones in which appropriate Diffie-Hellman hardness results
-apply.
+Component KEMs MUST be IND-CCA-secure {{GHP2018}} {{XWING}}.
 
-KDFs must be random oracles in the ROM and QROM.  (This seems to be the
-assumption made in both {{GHP2018}} and {{XWING}}.)  The choice of the KDF for
-HPKE SHOULD be made based on the security level provided by the constituent
-KEMs. The KDF SHOULD at least have the security level of the strongest
-constituent KEM.
+For instances of QSF, the component KEM MUST also be ciphertext second
+preimage resistant (C2PRI) {{XWING}}: this allows the component KEM
+encapsulation key and ciphertext to be left out from the KDF input. 
+
+### Security Requirements for Groups
+
+The groups MUST be modelable as nominal groups in which the strong
+Diffie-Hellman problem holds {{ABH+21}} {{XWING}}.
+
+The Montgomery curves Curve25519 and Curve448 have been shown to be
+modelable as nominal groups in {{ABH+21}} as well as showing the 
+`X25519()` and `X448()` functions respectively pertain to the nominal
+group `exp(X, y)` function, specifically clamping secret keys when
+they are generated, instead of clamping secret keys together with
+exponentiation.
+
+<!-- The short Weierstrass NIST curves have also been shown to be
+modelable as nominal groups but I can't find the reference --> 
+
+### Security Requirements for KDFs
+
+KDFs MUST be secure pseudorandom functions (PRFs) when keyed with
+the shared secret output from the post-quantum IND-CCA-secure
+KEM component algorithm in QSF {{XWING}} or any of the component
+IND-CCA-secure KEMs when used in KitchenSink {{GHP2018}} or
+PreHash.
+
+KDFs must be secure instances of random oracles in the ROM and
+QROM {{GHP2018}} {{XWING}}. Proofs of indifferentiability from
+random oracles {{MRH03 https://eprint.iacr.org/2003/161.pdf}}
+give good confidence here, as any function proven indifferentiable
+from a random oracle is resistant against collision, first, and
+second preimage attacks {{need a good cite here}}. An indifferentiability
+bound guarantees security against specific attacks. Although
+indifferentiability does not capture all properties of a random
+oracle {{RSS11 https://eprint.iacr.org/2011/339.pdf}}, indifferentiability
+still remains the best way to rule out structural attacks.
+
+Sponge-based constructions such as SHA-3 have been shown to be
+indifferentiable against classical {{BDP+08 https://www.iacr.org/archive/eurocrypt2008/49650180/49650180.pdf}}
+as well as quantum adversaries 
+{{ACM+25 https://eprint.iacr.org/2025/731.pdf}}. 
+
+HKDF has been shown to be indifferentiable from a random oracle under
+specific constraints {{LBB20 https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8806752}}: 
+
+- that HMAC is indifferentiable from a random oracle,
+which for HMAC-SHA-256 has been shown in {{}} {{DRS+13 https://eprint.iacr.org/2013/382.pdf}}, assuming the
+compression function underlying SHA-256 is a random oracle,
+which it is indifferentiably when used prefix-free.
+
+- the values of `HKDF`'s `IKM` input do not collide with
+values of `info` `||` `0x01`. This MUST be enforced by the
+concrete instantiations that use `HKDF` as its KDF. 
+
+The choice of the KDF security level SHOULD be made based on the
+security level provided by the constituent KEMs. The KDF SHOULD
+at least have the security level of the strongest constituent KEM.
+
+### Security Requirements for XOFs
+
+XOFs accept arbitrary bitstrings as input, and produce
+a caller-chosen-length prefix of an infinite bitstream
+deterministically defined by the input.
+
+<!-- requirements: secure PRF, bc key material? -->
+
 
 ## Security Properties of Hybrid KEMs
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -172,9 +172,8 @@ properties as long as the undelying algorithms are secure.
 Post-quantum (PQ) cryptographic schemes offer new constructions based on problems conjectured as resistant to attacks possible on a quantum computer. Key Encapsulation Mechanisms
 (KEMs), are a standardized algorithm type that can be used to build protocols in
 lieu of traditional, quantum-vulnerable variants such as finite field or
-elliptic curve Diffie-Hellman (DH) based protocols. Upgrading key establishment
-protocols to use PQ KEMs is a priority for the protocol design community, due to
-the possibility of "harvest now, decrypt later" attacks.
+lieu of traditional, quantum-vulnerable variants such as finite field or
+elliptic curve Diffie-Hellman (DH) based protocols.
 
 Given the novelty of PQ algorithms, however, there is some concern that PQ
 algorithms currently believed to be secure will be broken.  Hybrid

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -232,6 +232,8 @@ following cryptographic primitives:
 
 - Key Encapsulation Mechanisms {{kems}}
 - Nominal Groups {{group}}
+- Key-derivation Functions {{kdfs}}
+- Extendable-output Functions {{xofs}}
 - Hash Functions {{hash}}
 
 In the remainder of this section, we describe functional aspects of these
@@ -314,6 +316,35 @@ byte strings, with fixed lengths:
 > opaque by default and serialized or deserialized as needed.  We also use
 > slightly different terminology for keys, emphasizing "encapsulation" and
 > "decapsulation" as opposed to "public" and "secret".
+
+## Key Derivation Function `KDF` {#kdf}
+
+A secure key derivation function (KDF) that is modeled as a secure
+pseudorandom function (PRF) in the standard model {{GHP2018}} and
+independent random oracle in the random oracle model (ROM) and quantum
+random oracle model. Generally a strong KDF will have a proof of
+indifferentiability from a random oracle.
+
+Examples of secure KDFs in practice include HKDF-SHA256 and SHA3.
+SHA-256 is not generally considered a strong KDF except under
+constrained circumstances {{CDMP2005}}.
+
+## Extendable-output function `XOF` {#xof}
+
+Extendable-output function (XOF). A function on bit strings in which the
+output can be extended to any desired length. Ought to satisfy the following
+properties as long as the specified output length is sufficiently long to
+prevent trivial attacks:
+
+1. (One-way) It is computationally infeasible to find any input that maps to
+   any new pre-specified output.
+
+2. (Collision-resistant) It is computationally infeasible to find any two
+   distinct inputs that map to the same output.
+
+MUST provide the bit-security required to source input randomness for PQ/T
+components from a seed that is expanded to a output length, of which a subset
+is passed to the component key generation algorithms.
 
 ## Hash functions {#hash}
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -272,7 +272,7 @@ A Key Encapsulation Mechanism (KEMs) comprises the following algorithms:
   public encapsulation key `ek` and a secret decapsulation key `dk`, each of
   which are byte strings.
 - `DeriveKeyPair(seed) -> (ek, dk)`: A deterministic algorithm that takes as
-input a seed `seed` and generates a public encapsulation key `ek` and a secret
+  input a seed `seed` and generates a public encapsulation key `ek` and a secret
   decapsulation key `dk`, each of which are byte strings.
 - `Encaps(ek) -> (ct, ss)`: A probabilistic encapsulation
   algorithm, which takes as input a public encapsulation key `ek` and outputs

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -27,7 +27,7 @@ informative:
       -
         ins: Michel Abdalla
       -
-        ins: Mihir Bellare1
+        ins: Mihir Bellare
       -
         ins: Phillip Rogaway
 
@@ -139,7 +139,7 @@ informative:
 
 --- abstract
 
-"Post-quantum" (PQ) algorithms promise to resist attack by a quantum computer,
+"Post-quantum" (PQ) algorithms are designed to resist attack by a quantum computer,
 in contrast to "traditional" algorithms.  However, given the novelty of PQ
 algorithms, there is some concern that PQ algorithms currently believed to be
 secure will be broken.  Hybrid constructions that combine both PQ and
@@ -169,18 +169,20 @@ properly, a hybrid KEM will retain the properties of either constituent KEM
 even if the other KEM is compromised.  If the PQ KEM is broken by new
 cryptanalysis, then the hybrid KEM should continue to provide security against
 non-quantum attackers by virtue of its traditional KEM component.  If the
-traditional KEM is brken by a quantum computer, then the hybrid KEM should
+traditional KEM is broken by a quantum computer, then the hybrid KEM should
 continue to resist quantum attack by virtue of its PQ KEM component.
 
-In this document, we define constructions for hybrid Key Encapsulation
-Mechanisms (KEMs) based on combining a traditional KEM and a PQ KEM.  Hybrid
-KEMs using these constructions provide strong security properties as long as
-the undelying algorithms are secure.
+In addition to guarding against algorithm flaws, this property also guards
+against flaws in implementations, such as timing attacks.  Hybrid KEMs can also
+facilitate faster deployment of PQ security by allowing applications to
+incorporate PQ algorithms while still meeting compliance requirements based on
+traditional algorithms.
 
-The aim of this document is provide a small set of techniques for constructing
-hybrid KEMs designed to achieve specific security properties given conforming
-component algorithms, that should be suitable for the vast majority of use
-cases.
+In this document, we define constructions for hybrid KEMs based on combining a
+traditional KEM and a PQ KEM.  The aim of this document is provide a small set
+of techniques for constructing hybrid KEMs designed to achieve specific security
+properties given conforming component algorithms, that should be suitable for
+the vast majority of use cases.
 
 # Requirements Notation
 
@@ -310,14 +312,10 @@ random oracle in the random oracle model (ROM).
 ## KEM from Diffie-Hellman {#group}
 
 This section describes a simple KEM built from a Diffie-Hellman group.  **This
-KEM is not IND-CCA secure**. It is, however IND-CPA secure under either the
-Decisional Diffie-Hellman assumption or the Hashed Decisional Diffie-Hellman
-assumption, depending on the details of the ElementToSharedSecret function
-{{ABR01}}.
-
-The KEM construction here differs from the DHKEM construction in the HPKE
-specification {{RFC9180}}.  DHKEM performs additional hashing steps to mix
-certain metadata into the shared secret; this construction is more minimal.
+KEM is not a secure KEM in the sense of the IND-CCA standard usually applied (it
+meets the lower IND-CPA standard {{ABR01}}), and thus should not be used on its
+own.**  However, using the constructions in this document, it can be used as a
+component of an IND-CCA hybrid KEM, as discussed in {{security-considerations}}.
 
 The traditional Diffie-Hellman construction depends on an abelian group G with a
 chosen group generator or "base point" `B`, in which the discrete-log problem is

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -344,7 +344,12 @@ byte strings, with fixed lengths:
            pkAB ========================= pkBA
 ~~~
 
-<!-- Yes we need to be able to model the group as a nominal group to make the proofs work, but we have proofs for the NIST curves and the Montgomery curves, I wouldn't be surprised if a nice prime order group like Ristretto or DoubleOdd could also be shown to be a nominal group; thoughts on putting the 'nominal' requirements in the bit at the bottom of the doc, and just leave this as 'Groups'? --> 
+<!-- Yes we need to be able to model the group as a nominal group to make the
+proofs work, but we have proofs for the NIST curves and the Montgomery curves,
+I wouldn't be surprised if a nice prime order group like Ristretto or DoubleOdd
+could also be shown to be a nominal group; thoughts on putting the 'nominal'
+requirements in the security bits at the bottom of the doc, and just leave this as
+'Groups'? --> 
 
 Nominal groups are an abstract model of elliptic curve groups, over which we
 instantiate Diffie-Hellman key agreement {{ABH+21}}.  A nominal group comprises

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -399,7 +399,7 @@ fixed lengths:
 
 # Hybrid KEM Generic Constructions {#generic-constructions}
 
-In this section, we define three constructions for hybrid KEMs:
+In this section, we define three generic constructions for hybrid KEMs:
 
 * HashEverything - A generic construction that is suitable for use with any choice
   of traditional and PQ KEMs, with minimal security assumptions on the

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -696,7 +696,7 @@ FO-transform KEM. Also called ciphertext collision resistance.
 > these requirements align with the requirements of the security proofs in the
 > literature, especially {{GHP2018}} and {{XWING}}.
 
-### Security Requirements for KEMs
+### Security Requirements for KEMs {#security-kems}
 
 Component KEMs MUST be IND-CCA-secure {{GHP2018}} {{XWING}}.
 
@@ -704,7 +704,7 @@ For instances of QSF, the component KEM MUST also be ciphertext second
 preimage resistant (C2PRI) {{XWING}}: this allows the component KEM
 encapsulation key and ciphertext to be left out from the KDF input. 
 
-### Security Requirements for Groups
+### Security Requirements for Groups {#security-groups}
 
 The groups MUST be modelable as nominal groups in which the strong
 Diffie-Hellman problem holds {{ABH+21}} {{XWING}}.
@@ -719,7 +719,7 @@ exponentiation.
 <!-- The short Weierstrass NIST curves have also been shown to be
 modelable as nominal groups but I can't find the reference --> 
 
-### Security Requirements for KDFs
+### Security Requirements for KDFs {#security-kdfs}
 
 KDFs MUST be secure pseudorandom functions (PRFs) when keyed with
 the shared secret output from the post-quantum IND-CCA-secure
@@ -759,7 +759,7 @@ The choice of the KDF security level SHOULD be made based on the
 security level provided by the constituent KEMs. The KDF SHOULD
 at least have the security level of the strongest constituent KEM.
 
-### Security Requirements for XOFs
+### Security Requirements for XOFs {#security-xofs}
 
 XOFs accept arbitrary bitstrings as input, and produce
 a caller-chosen-length prefix of an infinite bitstream

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -515,51 +515,11 @@ ekh = KeyHash(concat(ek_T, ek_PQ))
 ss_H = CombinerHash(concat(ss_PQ, ss_T, ct_PQ, ct_T, ekh, label))
 ~~~
 
-### Instantiation with a Nominal Group
 
-The HashEverything and PreHashedKeys hybrid KEMs can be instantiated with a
-nominal group in place of the traditional KEM.  However, because the group
-construction used as a constituent does not comprise a secure KEM, these
-constructions are defined and analyzed separately.
 
-To instantiate the HashEverything or PreHashedKeys hybrid KEM with a nominal
-group, the traditional KEM `KEM_T` is replaced with a "pseudo-KEM" `PseudoKEM_T`
-based on a nominal group `Group_T`.  We use the term "pseudo-KEM" because while
-this construction meets the KEM API definition, it is not a secure KEM.
-
-The constants for the pseudo-KEM are defined as follows:
 
 ~~~
-PseudoKEM_T.Nseed = Group_T.Nseed
-PseudoKEM_T.Nek = GroupT.Nelem
-PseudoKEM_T.Ndk = GroupT.Nscalar
-PseudoKEM_T.Nct = GroupT.Nelem
-PseudoKEM_T.Nss = GroupT.Nss
-~~~
 
-The pseudo-KEM interface methods are defined as follows:
-
-~~~
-def PseudoGenerateKeyPair():
-    return DeriveKeyPair(random(Group_T.Nseed))
-
-def PseudoDeriveKeyPair(seed):
-    dk = Group_T.RandomScalar(seed)
-    ek = Group_T.Exp(Group_T.g, dk)
-    return (ek, dk)
-
-def PseudoEncaps(ek):
-    ct, sk_E = GenerateKeyPair()
-    ss = GroupT.ElementToSharedSecret(Group_T.Exp(ek, sk_E))
-    return (ct, ss)
-
-def PseudoDecaps(dk, ct):
-    return GroupT.ElementToSharedSecret(Group_T.Exp(ct, dk))
-~~~
-
-The HashEverything and PreHashedKeys hybrid KEMs are instantiated with a
-nominal group by replacing the `KEM_T` methods with the corresponding `Pseudo`
-methods.
 
 ## HashTraditionalOnly
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -344,11 +344,12 @@ byte strings, with fixed lengths:
            pkAB ========================= pkBA
 ~~~
 
-Nominal groups are an abstraction that represents the core mechanics of
-Diffie-Hellman key exchange, including both finite field and elliptic-curve
-Diffie-Hellman {{ABH+21}}.  A nominal group comprises a set `G` together with a
-distinguished basis element `g`, an "exponentiation" map, and some auxiliary
-functions:
+<!-- Yes we need to be able to model the group as a nominal group to make the proofs work, but we have proofs for the NIST curves and the Montgomery curves, I wouldn't be surprised if a nice prime order group like Ristretto or DoubleOdd could also be shown to be a nominal group; thoughts on putting the 'nominal' requirements in the bit at the bottom of the doc, and just leave this as 'Groups'? --> 
+
+Nominal groups are an abstract model of elliptic curve groups, over which we
+instantiate Diffie-Hellman key agreement {{ABH+21}}.  A nominal group comprises
+a set `G` together with a distinguished basis element `g`, an "exponentiation"
+map, and some auxiliary functions:
 
 - `Exp(p, x) -> q`: An algorithm that produces an element `q` of `G` from an
   element `p` and an integer `x`.

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -395,6 +395,25 @@ instead of `Foo.Derive(input)`.
 The security requirements for KDFs used with the schemes in this document are
 laid out in {{security-requirements}}.
 
+<!-- We must include XOFs because of X-Wing at the least but also because different KEMs/ groups may need different input seed sizes out the back of the function, and pure hash functions are not well suited for this; HKDF allows this via Expand(..., length) but X-Wing does not use HKDF -->
+
+## `XOF` {#xofs}
+
+Extendable-output function (XOF). A function on bit strings in which the
+output can be extended to any desired length. Ought to satisfy the following
+properties as long as the specified output length is sufficiently long to
+prevent trivial attacks:
+
+1. (One-way) It is computationally infeasible to find any input that maps to
+   any new pre-specified output.
+
+2. (Collision-resistant) It is computationally infeasible to find any two
+   distinct inputs that map to the same output.
+
+MUST provide the bit-security required to source input randomness for PQ/T
+components from a seed that is expanded to a output length, of which a subset
+is passed to the component key generation algorithms.
+
 # Hybrid KEM Schemes {#schemes}
 
 In this section, we define three schemes for building for hybrid KEMs:

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -217,7 +217,7 @@ The following terms are used throughout this document:
   `N1` bytes and its last `N2` bytes.  This function is the inverse of
   `concat(x1, x2)` when `x1` is `N1` bytes long and `x2` is `N2` bytes long. It
   is an error to call this function with a byte string that does not have length
-  `N1 + N2`.
+  `N1 + N2`. Since this function operates over secret data it MUST be constant-time.
 
 When `x` is a byte string, we use the notation `x[..i]` and `x[i..]` to
 denote the slice of bytes in `x` starting from the beginning of `x` and

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -192,7 +192,7 @@ facilitate faster deployment of PQ security by allowing applications to
 incorporate PQ algorithms while still meeting compliance requirements based on
 traditional algorithms.
 
-In this document, we define constructions for hybrid KEMs based on combining a
+In this document, we define generic constructions for hybrid KEMs based on combining a
 traditional algorithm and a PQ KEM.  The aim of this document is provide a small
 set of techniques for constructing hybrid KEMs designed to achieve specific
 security properties given conforming component algorithms, which should make it

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -247,6 +247,7 @@ following cryptographic primitives:
 - Key Encapsulation Mechanisms ({{kems}})
 - Nominal Groups ({{groups}})
 - Key Derivation Functions ({{kdfs}})
+- Extendable-Output Functions ({{xofs}})
 
 In the remainder of this section, we describe functional aspects of these
 mechanisms.  The security properties we require in order for the resulting

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -175,7 +175,7 @@ Encapsulation Mechanisms (KEMs), are a standardized class of cryptographic schem
 that can be used to build protocols in lieu of traditional, quantum-vulnerable
 variants such as finite field or elliptic curve Diffie-Hellman (DH) based protocols.
 
-Given the novelty of PQ algorithms, however, there is some concern that PQ
+Given the novelty of these PQ schemes however, there is some concern that PQ
 algorithms currently believed to be secure will be broken.  Hybrid
 constructions that combine both PQ and traditional algorithms can help moderate
 this risk while still providing security against quantum attack.  If construted

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -295,7 +295,7 @@ as opposed to "public" and "secret".
 Functionally, a hash function is simply a function that produces a fixed-length
 output byte string from an input byte string of arbitrary length.
 
-- `Nh` - The length in bytes of an output from this hash function. 
+- `Nh` - The length in bytes of an output from this hash function.
 - `Hash(input) -> output`: Produce a byte string of length `Nh` from an input
   byte string.
 
@@ -305,31 +305,10 @@ as `Foo(input)` instead of `Foo.Hash(input)`.
 
 Hash function used with the constructions in this document should be structured
 so that they can be regarded as random oracles in either the classical or
-quantum random oracle model.
-
-
-## `XOF` {#xof}
-
-Extendable-output function (XOF). A function on bit strings in which the
-output can be extended to any desired length. Ought to satisfy the following
-properties as long as the specified output length is sufficiently long to
-prevent trivial attacks:
-
-1. (One-way) It is computationally infeasible to find any input that maps to
-   any new pre-specified output.
-
-2. (Collision-resistant) It is computationally infeasible to find any two
-   distinct inputs that map to the same output.
-
-MUST provide the bit-security required to source input randomness for PQ/T
-components from a seed that is expanded to a output length, of which a subset
-is passed to the component key generation algorithms.
-
-## Key Derivation Function `KDF` {#kdf}
-
-A secure key derivation function (KDF) that is modeled as a secure
-pseudorandom function (PRF) in the standard model {{GHP2018}} and independent
-random oracle in the random oracle model (ROM).
+quantum random oracle model.  (Note that this property implies standard hash
+function properties such as collision resistance and second preimage
+resistance.)  Each hash function we refer to should be an independent random
+oracle.
 
 ## KEM from Diffie-Hellman {#group}
 
@@ -542,19 +521,20 @@ hashes for no utility, and the `Everything` combiner should be preferred.
 
 <!-- TODO example: Raw ECDH + Classic McEliece -->
 
-### Traditional Only
+### Only Traditional
 
 ```
-def Traditional(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
+def Only Traditional(ss_T, ss_PQ, ct_T, ct_PQ, ek_T, ek_PQ, label):
     return concat(ss_PQ, ss_T, ct_T, ek_T, label)
 ```
 
 This combiner produces an even smaller hash input than the `PreHashedKeys`
-combiner, even in cases where keys are not reused.
+combiner, even in cases where keys are not reused, by hashing only the
+traditional metadata.
 
 It is, however, less universal than the `Everything` or `PreHashedKeys`
 combiners.  Its security depends on the constituent KEMs having certain
-additional properties, as discussed in {{traditional-only-sec}}.
+additional properties, as discussed in {{only-traditional-sec}}.
 
 <!-- TODO example: Raw ECDH + ML-KEM -->
 
@@ -573,6 +553,26 @@ stringent requirements on the constituent KEMs, as discussed in
 <!-- For example: DHKEM + ML-KEM -->
 
 # Security Considerations
+
+## Security Properties
+
+### INDistinguishability against Chosen-Ciphertext Attacks (IND-CCA)
+
+### Ciphertext Second Preimage Resistance (C2PR)
+
+### Binding Properties (X-BIND-P-Q)
+
+### Survival if One KEM Fails
+
+## Security of the Combiners
+
+### Everything {#everything-sec}
+
+### OnlyTraditional {#only-traditional-sec}
+
+### OnlySharedSecrets {#only-shared-secrets-sec}
+
+# Security Considerations (Original)
 
 Hybrid KEM constructions aim to provide security by combining two or more
 schemes so that security is preserved if all but one schemes are replaced by

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -491,7 +491,7 @@ def Decaps(dk, ct):
     return ss_H
 ~~~
 
-### Optimization for Encapsulation Key Reuse
+## PreHash {#prehash}
 
 The PreHashedKeys hybrid KEM is a performance optimization of the HashEverything
 KEM, optimized for the case where encapsulation keys are large and frequently

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -401,12 +401,12 @@ fixed lengths:
 
 In this section, we define three constructions for hybrid KEMs:
 
-* HashEverything - A generic combiner that is suitable for use with any choice
+* HashEverything - A generic construction that is suitable for use with any choice
   of traditional and PQ KEMs, with minimal security assumptions on the
   constituent KEMs
 * PreHashedKeys - A performance optimization of HashEverything for the case
   where encapsulation keys are large and frequently reused
-* HashTraditionalOnly - An optimized combiner for the case where the traditional
+* HashTraditionalOnly - An optimized generic construction for the case where the traditional
   component is a nominal group and the PQ component has strong binding
   properties
 


### PR DESCRIPTION
This PR rewrites the hybrid KEMs in terms of nominal groups as appropriate.

* Adds a "nominal group" API much like the KEM API.
* The HashEverything hybrid is defined in terms of KEM+KEM
    * The PreHashKeys hybrid is defined as an optimization of HashEverything
    * We define a way of instantiating the above with a group instead of a KEM
* The HashTraditionalOnly hybrid is define in terms of Group+KEM (as in [BCD+24])
