### PR TITLE
Some abstract editing

### DIFF
--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -211,9 +211,10 @@ informative:
 --- abstract
 
 This document defines generic constructions for hybrid Key Encapsulation
-Mechanisms (KEMs) based on combining a traditional KEM and a post-quantum (PQ)
-KEM. Hybrid KEMs built using these constructions provide strong security
-properties as long as either of the underlying algorithms are secure.
+Mechanisms (KEMs) based on combining a traditional cryptographic component
+and a post-quantum (PQ) KEM. Hybrid KEMs built using these constructions
+provide strong security properties as long as either of the underlying
+algorithms are secure.
 
 --- middle
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -210,18 +210,10 @@ informative:
 
 --- abstract
 
-Post-quantum (PQ) algorithms are designed to resist attack by a quantum
-computer, in contrast to "traditional" algorithms.  However, given the
-novelty of PQ algorithms, there is some concern that PQ algorithms currently
-believed to be secure will be broken.  Hybrid constructions that combine both
-PQ and traditional algorithms can help moderate this risk while still
-providing security against quantum attack.
-
-This document defines
-constructions for hybrid Key Encapsulation Mechanisms (KEMs) based on
-combining a traditional KEM and a PQ KEM. Hybrid KEMs using these
-constructions provide strong security properties as long as either of the
-underlying algorithms are secure.
+This document defines generic constructions for hybrid Key Encapsulation
+Mechanisms (KEMs) based on combining a traditional KEM and a post-quantum (PQ)
+KEM. Hybrid KEMs built using these constructions provide strong security
+properties as long as either of the underlying algorithms are secure.
 
 --- middle
 

--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -215,11 +215,13 @@ computer, in contrast to "traditional" algorithms.  However, given the
 novelty of PQ algorithms, there is some concern that PQ algorithms currently
 believed to be secure will be broken.  Hybrid constructions that combine both
 PQ and traditional algorithms can help moderate this risk while still
-providing security against quantum attack. In this document, we define
+providing security against quantum attack.
+
+This document defines
 constructions for hybrid Key Encapsulation Mechanisms (KEMs) based on
 combining a traditional KEM and a PQ KEM. Hybrid KEMs using these
-constructions provide strong security properties as long as the undelying
-algorithms are secure.
+constructions provide strong security properties as long as either of the
+underlying algorithms are secure.
 
 --- middle
 


### PR DESCRIPTION
This was originally just a typo fix for a missing 'r'.  But then you had a "we", that was unnecessary.

I split this into two paragraphs, but I'm going to suggest that you delete the first one entirely.  Everything that is needed is in the second.