### PR TITLE
I was going to do more of this,

### DIFF
--- a/draft-irtf-cfrg-hybrid-kems.md
+++ b/draft-irtf-cfrg-hybrid-kems.md
@@ -141,6 +141,10 @@ informative:
     title: "KEM Combiners"
     target: https://eprint.iacr.org/2018/024.pdf
     date: 2018
+    author:
+     - name: Federico Giacon
+     - name: Felix Heuer
+     - name: Bertram Poettering
   GMP22:
     title: "Anonymous, Robust Post-Quantum Public-Key Encryption"
     target: https://eprint.iacr.org/2021/708.pdf


### PR DESCRIPTION
but there are too many.

You might consider removing the ".pdf" extension from the URLs, so that people can hit the ePrint landing page instead.